### PR TITLE
Upgrade to bevy 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_console"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["RichoDemus <git@richodemus.com>"]
 homepage = "https://github.com/RichoDemus/bevy-console"
@@ -10,13 +10,13 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-bevy = { version = "0.6", default-features = false }
+bevy = { version = "0.7.0", default-features = false }
 bevy_console_derive = { path = "./bevy_console_derive", version = "0.3.0" }
 bevy_console_parser = { path = "./bevy_console_parser", version = "0.3.0" }
-bevy_egui = "0.11"
+bevy_egui = "0.13.0"
 
 [dev-dependencies]
-bevy = "0.6"
+bevy = "0.7.0"
 
 [workspace]
 members = ["bevy_console_derive", "bevy_console_parser"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ A simple half-life inspired console with support for argument parsing.
   <img src="https://raw.githubusercontent.com/richodemus/bevy-console/main/doc/screenshot.png" width="100%">
 </p>
 
+## Bevy support
+
+
+| bevy_console version | Supported Bevy version |
+|----------------------|------------------------|
+| 0.3                  | 0.6                    |
+| 0.4                  | 0.7                    |
+
 ## Usage
 
 Add `ConsolePlugin` and optionally the resource `ConsoleConfiguration`.


### PR DESCRIPTION
Makes the plugin compatible with Bevy 0.7.

Note: I mostly just blindly fixed these according to what made sense. I haven't tested it much aside from opening the console and running a single command. But the changes are pretty innocent.