### PR TITLE
Use bevy w/o default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-bevy = "0.8"
+bevy = { version = "0.8", default-features = false }
 bevy_console_derive = { path = "./bevy_console_derive", version = "0.3.0" }
 bevy_console_parser = { path = "./bevy_console_parser", version = "0.3.0" }
 bevy_egui = "0.16"


### PR DESCRIPTION
`bevy_console` is only using the core of Bevy and none of its `default-features`. It can therefore disable default features so it doesn't enable them for its dependents.

This allows to use `bevy_console` alongside crates that require cherry-picking particular Bevy features and disabling some default ones, such as `bevy_kira_audio`.