### PR TITLE
Set console line prefix symbol/String

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -425,6 +425,8 @@ pub struct ConsoleConfiguration {
     pub commands: BTreeMap<&'static str, Option<CommandInfo>>,
     /// Number of commands to store in history
     pub history_size: usize,
+    ///Line prefix symbol
+    pub symbol: String,
 }
 
 impl Default for ConsoleConfiguration {
@@ -437,6 +439,7 @@ impl Default for ConsoleConfiguration {
             width: 800.0,
             commands: BTreeMap::new(),
             history_size: 20,
+            symbol: "$".to_owned()
         }
     }
 }
@@ -577,7 +580,7 @@ pub(crate) fn console_ui(
                         if state.buf.trim().is_empty() {
                             state.scrollback.push(String::new());
                         } else {
-                            let msg = format!("$ {}", state.buf);
+                            let msg = format!("{} {}", config.symbol, state.buf);
                             state.scrollback.push(msg);
                             let cmd_string = state.buf.clone();
                             state.history.insert(1, cmd_string);

--- a/src/console.rs
+++ b/src/console.rs
@@ -439,7 +439,7 @@ impl Default for ConsoleConfiguration {
             width: 800.0,
             commands: BTreeMap::new(),
             history_size: 20,
-            symbol: "$".to_owned()
+            symbol: "$ ".to_owned()
         }
     }
 }
@@ -580,7 +580,7 @@ pub(crate) fn console_ui(
                         if state.buf.trim().is_empty() {
                             state.scrollback.push(String::new());
                         } else {
-                            let msg = format!("{} {}", config.symbol, state.buf);
+                            let msg = format!("{}{}", config.symbol, state.buf);
                             state.scrollback.push(msg);
                             let cmd_string = state.buf.clone();
                             state.history.insert(1, cmd_string);


### PR DESCRIPTION
I've added a simple setting to change default "$ " prefix into any String. The space between prefix and comand is also part of prefix, it can be removed by using "$" instead of "$ ".
Defaults to "$ ". Can be changed under ConsoleConfiguration. Changing the prefix mid-run is possible.

![img](https://user-images.githubusercontent.com/72872571/202842254-9488bb75-f279-427c-811d-377d916dd3ac.png)
