### PR TITLE
Bump bevy_egui to 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 bevy = { version = "0.9", default-features = false }
 clap = { version = "=4.0.32", features = ["derive"]}
 bevy_console_derive = { path = "./bevy_console_derive", version = "0.5.0" }
-bevy_egui = "0.17"
+bevy_egui = "0.19"
 
 [dev-dependencies]
 bevy = "0.9"


### PR DESCRIPTION
Ran into some compatibility issues when using at the same time with bevy_inspector_egui.