### PR TITLE
Add support for Bevy 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-bevy = { version = "0.9", default-features = false }
-clap = { version = "=4.0.32", features = ["derive"]}
+bevy = { version = "0.10", default-features = false }
+clap = { version = "=4.1.10", features = ["derive"]}
 bevy_console_derive = { path = "./bevy_console_derive", version = "0.5.0" }
-bevy_egui = "0.17"
+bevy_egui = "0.20.1"
 
 [dev-dependencies]
-bevy = "0.9"
+bevy = "0.10"
 
 [workspace]
 members = ["bevy_console_derive"]

--- a/examples/raw_commands.rs
+++ b/examples/raw_commands.rs
@@ -1,11 +1,11 @@
 use bevy::prelude::*;
-use bevy_console::{ConsoleCommandEntered, ConsolePlugin};
+use bevy_console::{ConsoleCommandEntered, ConsolePlugin, ConsoleSet};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(ConsolePlugin)
-        .add_system(raw_commands)
+        .add_system(raw_commands.in_set(ConsoleSet::Commands))
         .run();
 }
 

--- a/examples/write_to_console.rs
+++ b/examples/write_to_console.rs
@@ -5,7 +5,11 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(ConsolePlugin)
-        .add_system(write_to_console.in_set(ConsoleSet::Commands))
+        // NOTE: this wouldn't work for this particular case,
+        // systems in the [`ConsoleSet::Commands`] do not run if there are no console commands entered
+        // .add_system(write_to_console.in_set(ConsoleSet::Commands))
+        // the below is the equivalent but without run conditions
+        .add_system(write_to_console.after(ConsoleSet::ConsoleUI))
         .run();
 }
 

--- a/examples/write_to_console.rs
+++ b/examples/write_to_console.rs
@@ -1,11 +1,11 @@
 use bevy::prelude::*;
-use bevy_console::{ConsolePlugin, PrintConsoleLine};
+use bevy_console::{ConsolePlugin, ConsoleSet, PrintConsoleLine};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(ConsolePlugin)
-        .add_system(write_to_console)
+        .add_system(write_to_console.in_set(ConsoleSet::Commands))
         .run();
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,11 @@ pub enum ConsoleSet {
     PostCommands,
 }
 
+/// Run condition which does not run any command systems if no command was entered
+fn have_commands(commands: EventReader<ConsoleCommandEntered>) -> bool {
+    !commands.is_empty()
+}
+
 impl Plugin for ConsolePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ConsoleConfiguration>()
@@ -52,7 +57,11 @@ impl Plugin for ConsolePlugin {
             .add_console_command::<HelpCommand, _>(help_command)
             .add_system(console_ui.in_set(ConsoleSet::ConsoleUI))
             .add_system(receive_console_line.in_set(ConsoleSet::PostCommands))
-            .configure_set(ConsoleSet::Commands.after(ConsoleSet::ConsoleUI))
+            .configure_set(
+                ConsoleSet::Commands
+                    .after(ConsoleSet::ConsoleUI)
+                    .run_if(have_commands),
+            )
             .configure_set(ConsoleSet::PostCommands.after(ConsoleSet::Commands));
 
         // Don't initialize an egui plugin if one already exists.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #![doc = include_str ! ("../README.md")]
 #![deny(missing_docs)]
 
-use bevy::prelude::{App, IntoSystemDescriptor, Plugin};
+use bevy::prelude::*;
 pub use bevy_console_derive::ConsoleCommand;
-use bevy_egui::{EguiContext, EguiPlugin};
+use bevy_egui::{EguiPlugin, EguiSettings};
 
 use crate::commands::clear::{clear_command, ClearCommand};
 use crate::commands::exit::{exit_command, ExitCommand};
@@ -24,6 +24,22 @@ mod macros;
 /// Console plugin.
 pub struct ConsolePlugin;
 
+#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
+/// The SystemSet for console/command related systems
+pub enum ConsoleSet {
+    /// Systems operating the console UI (the input layer)
+    ConsoleUI,
+
+    /// Systems executing console commands (the functionality layer).
+    /// All command handler systems are added to this set
+    Commands,
+
+    /// Systems running after command systems, which depend on the fact commands have executed beforehand (the output layer).
+    /// For example a system which makes use of [`PrintConsoleLine`] events should be placed in this set to be able to receive
+    /// New lines to print in the same frame
+    PostCommands,
+}
+
 impl Plugin for ConsolePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ConsoleConfiguration>()
@@ -34,12 +50,14 @@ impl Plugin for ConsolePlugin {
             .add_console_command::<ClearCommand, _>(clear_command)
             .add_console_command::<ExitCommand, _>(exit_command)
             .add_console_command::<HelpCommand, _>(help_command)
-            .add_system(console_ui.at_end())
-            .add_system(receive_console_line);
+            .add_system(console_ui.in_set(ConsoleSet::ConsoleUI))
+            .add_system(receive_console_line.in_set(ConsoleSet::PostCommands))
+            .configure_set(ConsoleSet::Commands.after(ConsoleSet::ConsoleUI))
+            .configure_set(ConsoleSet::PostCommands.after(ConsoleSet::Commands));
 
-        // Don't create an egui context if one already exists.
+        // Don't initialize an egui plugin if one already exists.
         // This can happen if another plugin is using egui and was installed before us.
-        if !app.world.contains_resource::<EguiContext>() {
+        if !app.world.contains_resource::<EguiSettings>() {
             app.add_plugin(EguiPlugin);
         }
     }


### PR DESCRIPTION
- Introduces `ConsoleSet` system set
  -  UI runs before commands and commands run before command processors
- bumps versions of Egui, Bevy and Clap
- Migrates bevy 0.10 code to be compatibile with Bevy 0.10