### PR TITLE
Clear scrollback on Ctrl+L

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -326,10 +326,13 @@ pub(crate) fn console_ui(
     mut egui_context: EguiContexts,
     config: Res<ConsoleConfiguration>,
     mut keyboard_input_events: EventReader<KeyboardInput>,
+    keys: Res<Input<KeyCode>>,
     mut state: ResMut<ConsoleState>,
     mut command_entered: EventWriter<ConsoleCommandEntered>,
     mut console_open: ResMut<ConsoleOpen>,
 ) {
+    let keyboard_input_events = keyboard_input_events.iter().collect::<Vec<_>>();
+
     let pressed = keyboard_input_events
         .iter()
         .any(|code| console_key_pressed(code, &config.keys));
@@ -429,6 +432,15 @@ pub(crate) fn console_ui(
 
                             state.buf.clear();
                         }
+                    }
+
+                    // Clear on ctrl+l
+                    if keyboard_input_events
+                        .iter()
+                        .any(|&k| k.state.is_pressed() && k.key_code == Some(KeyCode::L))
+                        && (keys.any_pressed([KeyCode::LControl, KeyCode::RControl]))
+                    {
+                        state.scrollback.clear();
                     }
 
                     // Handle up and down through history


### PR DESCRIPTION
bash, powershell, fish etc. clears on ctrl+l

It's pretty ingrained in my muscle memory, so thought I'd add it.