### PR TITLE
Update to Bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_console"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["RichoDemus <git@richodemus.com>"]
 homepage = "https://github.com/RichoDemus/bevy-console"
@@ -10,13 +10,13 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-bevy = { version = "0.10", default-features = false }
+bevy = { version = "0.11", default-features = false }
 clap = { version = "=4.1.10", features = ["derive"]}
 bevy_console_derive = { path = "./bevy_console_derive", version = "0.5.0" }
-bevy_egui = "0.20.1"
+bevy_egui = "0.21"
 
 [dev-dependencies]
-bevy = "0.10"
+bevy = "0.11"
 
 [workspace]
 members = ["bevy_console_derive"]

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ use bevy_console::{ConsoleConfiguration, ConsolePlugin};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(ConsolePlugin)
+        .add_plugins((DefaultPlugins, ConsolePlugin))
         .insert_resource(ConsoleConfiguration {
             // override config here
             ..Default::default()
@@ -38,8 +37,7 @@ use clap::Parser;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(ConsolePlugin)
+        .add_plugins((DefaultPlugins, ConsolePlugin))
         .add_console_command::<ExampleCommand, _>(example_command);
 }
 

--- a/examples/change_console_key.rs
+++ b/examples/change_console_key.rs
@@ -3,8 +3,7 @@ use bevy_console::{ConsoleConfiguration, ConsolePlugin, ToggleConsoleKey};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(ConsolePlugin)
+        .add_plugins((DefaultPlugins, ConsolePlugin))
         .insert_resource(ConsoleConfiguration {
             keys: vec![
                 ToggleConsoleKey::ScanCode(41), // Console key on a swedish keyboard

--- a/examples/log_command.rs
+++ b/examples/log_command.rs
@@ -4,8 +4,7 @@ use clap::Parser;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(ConsolePlugin)
+        .add_plugins((DefaultPlugins, ConsolePlugin))
         .add_console_command::<LogCommand, _>(log_command)
         .run();
 }

--- a/examples/raw_commands.rs
+++ b/examples/raw_commands.rs
@@ -3,9 +3,8 @@ use bevy_console::{ConsoleCommandEntered, ConsolePlugin, ConsoleSet};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(ConsolePlugin)
-        .add_system(raw_commands.in_set(ConsoleSet::Commands))
+        .add_plugins((DefaultPlugins, ConsolePlugin))
+        .add_systems(Update, raw_commands.in_set(ConsoleSet::Commands))
         .run();
 }
 

--- a/examples/write_to_console.rs
+++ b/examples/write_to_console.rs
@@ -3,13 +3,12 @@ use bevy_console::{ConsolePlugin, ConsoleSet, PrintConsoleLine};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
-        .add_plugin(ConsolePlugin)
+        .add_plugins((DefaultPlugins, ConsolePlugin))
         // NOTE: this wouldn't work for this particular case,
         // systems in the [`ConsoleSet::Commands`] do not run if there are no console commands entered
-        // .add_system(write_to_console.in_set(ConsoleSet::Commands))
+        // .add_systems(Update, write_to_console.in_set(ConsoleSet::Commands))
         // the below is the equivalent but without run conditions
-        .add_system(write_to_console.after(ConsoleSet::ConsoleUI))
+        .add_systems(Update, write_to_console.after(ConsoleSet::ConsoleUI))
         .run();
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,19 +55,27 @@ impl Plugin for ConsolePlugin {
             .add_console_command::<ClearCommand, _>(clear_command)
             .add_console_command::<ExitCommand, _>(exit_command)
             .add_console_command::<HelpCommand, _>(help_command)
-            .add_system(console_ui.in_set(ConsoleSet::ConsoleUI))
-            .add_system(receive_console_line.in_set(ConsoleSet::PostCommands))
-            .configure_set(
-                ConsoleSet::Commands
-                    .after(ConsoleSet::ConsoleUI)
-                    .run_if(have_commands),
+            .add_systems(
+                Update,
+                (
+                    console_ui.in_set(ConsoleSet::ConsoleUI),
+                    receive_console_line.in_set(ConsoleSet::PostCommands),
+                ),
             )
-            .configure_set(ConsoleSet::PostCommands.after(ConsoleSet::Commands));
+            .configure_sets(
+                Update,
+                (
+                    ConsoleSet::Commands
+                        .after(ConsoleSet::ConsoleUI)
+                        .run_if(have_commands),
+                    ConsoleSet::PostCommands.after(ConsoleSet::Commands),
+                ),
+            );
 
         // Don't initialize an egui plugin if one already exists.
         // This can happen if another plugin is using egui and was installed before us.
         if !app.world.contains_resource::<EguiSettings>() {
-            app.add_plugin(EguiPlugin);
+            app.add_plugins(EguiPlugin);
         }
     }
 }


### PR DESCRIPTION
This PR updates `bevy-console` to Bevy **0.11**.

The main changes (besides `README.md` and doctest cleanup) are the usage of `add_plugins(...)` and `add_systems(...)` everywhere as the old `add_plugin(...)` and `add_system(...)` methods have been deprecated. A few changes were needed, such as:
- Update `get_param()` usage to include parameter changes from base `SystemParam`
- Derive `Event` for Bevy events
- Update tests using `KeyboardInput` to add the required `window` field (set to `Entity::PLACEHOLDER`)