### PR TITLE
fix compatibility with bevy-inspector-egui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 bevy = { version = "0.11", default-features = false }
 clap = { version = "=4.1.10", features = ["derive"]}
 bevy_console_derive = { path = "./bevy_console_derive", version = "0.5.0" }
-bevy_egui = "0.21"
+bevy_egui = "0.22"
 shlex = "1.1"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 
 use bevy::prelude::*;
 pub use bevy_console_derive::ConsoleCommand;
-use bevy_egui::{EguiPlugin, EguiSettings};
+use bevy_egui::EguiPlugin;
 
 use crate::commands::clear::{clear_command, ClearCommand};
 use crate::commands::exit::{exit_command, ExitCommand};
@@ -74,7 +74,7 @@ impl Plugin for ConsolePlugin {
 
         // Don't initialize an egui plugin if one already exists.
         // This can happen if another plugin is using egui and was installed before us.
-        if !app.world.contains_resource::<EguiSettings>() {
+        if !app.is_plugin_added::<EguiPlugin>() {
             app.add_plugins(EguiPlugin);
         }
     }


### PR DESCRIPTION
Bumping the version of bevy_egui was necessary since bevy-inspector-egui 0.18.3 is the latest compatible version and is not compatible with the latest bevy.