### PR TITLE
Change println! to info! in raw_commands example

### DIFF
--- a/examples/raw_commands.rs
+++ b/examples/raw_commands.rs
@@ -10,6 +10,6 @@ fn main() {
 
 fn raw_commands(mut console_commands: EventReader<ConsoleCommandEntered>) {
     for ConsoleCommandEntered { command_name, args } in console_commands.iter() {
-        println!(r#"Entered command "{command_name}" with args {:#?}"#, args);
+        info!(r#"Entered command "{command_name}" with args {:#?}"#, args);
     }
 }


### PR DESCRIPTION
You should use `info!` instead of `println!` for logging stuff.