### PR TITLE
Update to Bevy 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_console"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 authors = ["RichoDemus <git@richodemus.com>"]
 homepage = "https://github.com/RichoDemus/bevy-console"
@@ -10,14 +10,14 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-bevy = { version = "0.11", default-features = false }
+bevy = { version = "0.12", default-features = false }
 clap = { version = "4.4.6", features = ["derive"] }
 bevy_console_derive = { path = "./bevy_console_derive", version = "0.5.0" }
-bevy_egui = "0.22"
+bevy_egui = "0.23"
 shlex = "1.1"
 
 [dev-dependencies]
-bevy = "0.11"
+bevy = "0.12"
 
 [workspace]
 members = ["bevy_console_derive"]

--- a/examples/raw_commands.rs
+++ b/examples/raw_commands.rs
@@ -9,7 +9,7 @@ fn main() {
 }
 
 fn raw_commands(mut console_commands: EventReader<ConsoleCommandEntered>) {
-    for ConsoleCommandEntered { command_name, args } in console_commands.iter() {
+    for ConsoleCommandEntered { command_name, args } in console_commands.read() {
         println!(r#"Entered command "{command_name}" with args {:#?}"#, args);
     }
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -150,7 +150,7 @@ unsafe impl<T: Command> SystemParam for ConsoleCommand<'_, T> {
             change_tick,
         );
 
-        let command = event_reader.iter().find_map(|command| {
+        let command = event_reader.read().find_map(|command| {
             if T::name() == command.command_name {
                 let clap_command = T::command().no_binary_name(true);
                 // .color(clap::ColorChoice::Always);
@@ -334,7 +334,7 @@ pub(crate) fn console_ui(
     mut command_entered: EventWriter<ConsoleCommandEntered>,
     mut console_open: ResMut<ConsoleOpen>,
 ) {
-    let keyboard_input_events = keyboard_input_events.iter().collect::<Vec<_>>();
+    let keyboard_input_events = keyboard_input_events.read().collect::<Vec<_>>();
     let ctx = egui_context.ctx_mut();
 
     let pressed = keyboard_input_events
@@ -479,7 +479,7 @@ pub(crate) fn receive_console_line(
     mut console_state: ResMut<ConsoleState>,
     mut events: EventReader<PrintConsoleLine>,
 ) {
-    for event in events.iter() {
+    for event in events.read() {
         let event: &PrintConsoleLine = event;
         console_state.scrollback.push(event.line.clone());
     }


### PR DESCRIPTION
This PR updates `bevy-console` to Bevy **0.12**, bumping the version to **0.10.0**.