### PR TITLE
Update to Bevy 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-bevy = { version = "0.12", default-features = false }
-clap = { version = "4.4.6", features = ["derive"] }
+bevy = { version = "0.13", default-features = false }
+clap = { version = "4.5", features = ["derive"] }
 bevy_console_derive = { path = "./bevy_console_derive", version = "0.5.0" }
-bevy_egui = "0.24"
-shlex = "1.1"
+bevy_egui = "0.25"
+shlex = "1.3"
 
 [dev-dependencies]
-bevy = "0.12"
+bevy = "0.13"
 
 [workspace]
 members = ["bevy_console_derive"]

--- a/examples/change_console_key.rs
+++ b/examples/change_console_key.rs
@@ -1,14 +1,21 @@
+use bevy::input::keyboard::NativeKeyCode;
 use bevy::prelude::*;
-use bevy_console::{ConsoleConfiguration, ConsolePlugin, ToggleConsoleKey};
+use bevy_console::{ConsoleConfiguration, ConsolePlugin};
 
 fn main() {
     App::new()
         .add_plugins((DefaultPlugins, ConsolePlugin))
         .insert_resource(ConsoleConfiguration {
             keys: vec![
-                ToggleConsoleKey::ScanCode(41), // Console key on a swedish keyboard
-                ToggleConsoleKey::KeyCode(KeyCode::Grave), // US console key
-                ToggleConsoleKey::KeyCode(KeyCode::F1),
+                // Console key on a swedish keyboard
+                KeyCode::Unidentified(NativeKeyCode::Android(41)),
+                KeyCode::Unidentified(NativeKeyCode::MacOS(41)),
+                KeyCode::Unidentified(NativeKeyCode::Windows(41)),
+                KeyCode::Unidentified(NativeKeyCode::Xkb(41)),
+                // US console key
+                KeyCode::Backquote,
+                // F1 key
+                KeyCode::F1,
             ],
             ..Default::default()
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use crate::commands::exit::{exit_command, ExitCommand};
 use crate::commands::help::{help_command, HelpCommand};
 pub use crate::console::{
     AddConsoleCommand, Command, ConsoleCommand, ConsoleCommandEntered, ConsoleConfiguration,
-    ConsoleOpen, NamedCommand, PrintConsoleLine, ToggleConsoleKey,
+    ConsoleOpen, NamedCommand, PrintConsoleLine,
 };
 // pub use color::{Style, StyledStr};
 


### PR DESCRIPTION
Hi, this PR updates Bevy to v0.13 and the other dependencies to latest versions. Scan codes are removed with Bevy v0.13 (https://bevyengine.org/learn/migration-guides/0-12-to-0-13/#keycode-changes) which is reflected in the PR. Hope it's good, let me know if you want any changes!