### PR TITLE
add tab-autocompletion, clear line with ctrl+c, fix minor bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,11 @@ cargo run --example log_command
 ## wasm
 
 Should work in wasm, but you need to disable default features.
+
+## Keyboard Shortcuts
+
+Some shortcuts:
+
+- Ctrl + L: Clear history
+- Ctrl + C: Clear line
+- Tab: Line completion

--- a/src/console.rs
+++ b/src/console.rs
@@ -382,6 +382,20 @@ pub(crate) fn console_ui(
                     // Separator
                     ui.separator();
 
+                    // Clear line on ctrl+c
+                    if ui.input(|i| i.modifiers.ctrl & i.key_pressed(egui::Key::C))
+                    {
+                        state.buf.clear();
+                        return;
+                    }
+                    
+                    // Clear history on ctrl+l
+                    if ui.input(|i| i.modifiers.ctrl & i.key_pressed(egui::Key::L))
+                    {
+                        state.scrollback.clear();
+                        return;
+                    }
+
                     // Input
                     let text_edit = TextEdit::singleline(&mut state.buf)
                         .desired_width(f32::INFINITY)
@@ -474,19 +488,6 @@ pub(crate) fn console_ui(
                                 state.buf = completions[0].to_string();
                             }
                         }
-                    }
-
-                    // Clear line on ctrl+c
-                    if ui.input(|i| i.modifiers.ctrl & i.key_pressed(egui::Key::C))
-                    {
-                        state.buf.clear();
-                    }
-
-                    // Clear history on ctrl+l
-                    if ui.input(|i| i.modifiers.ctrl & i.key_pressed(egui::Key::L))
-                    {
-                        state.scrollback.clear();
-                        state.buf = state.buf[0..(state.buf.len() - 1)].to_string();
                     }
 
                     // Handle up and down through history

--- a/src/console.rs
+++ b/src/console.rs
@@ -492,6 +492,7 @@ pub(crate) fn console_ui(
                         && (keys.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight]))
                     {
                         state.scrollback.clear();
+                        state.buf = state.buf[0..(state.buf.len() - 1)].to_string();
                     }
 
                     // Handle up and down through history

--- a/src/console.rs
+++ b/src/console.rs
@@ -223,7 +223,7 @@ pub struct ConsoleConfiguration {
     pub symbol: String,
     /// Custom argument completions for commands.
     /// Key is the command, entries are potential completions.
-    pub custom_arg_completions: HashMap<String, Vec<String>>,
+    pub arg_completions: HashMap<String, Vec<String>>,
 }
 
 impl Default for ConsoleConfiguration {
@@ -237,7 +237,7 @@ impl Default for ConsoleConfiguration {
             commands: BTreeMap::new(),
             history_size: 20,
             symbol: "$ ".to_owned(),
-            custom_arg_completions: HashMap::new(),
+            arg_completions: HashMap::new(),
         }
     }
 }
@@ -463,7 +463,7 @@ pub(crate) fn console_ui(
                                 + &full_word;
                             state.buf = full_line;
                         } else if line_words.len() > 1 { // create cycle to autocomplete arguments
-                            if let Some(args_completions) = config.custom_arg_completions.get(line_words[0]) {
+                            if let Some(args_completions) = config.arg_completions.get(line_words[0]) {
                                 let completions: Vec<String> = args_completions.iter()
                                     .filter(|x| x.starts_with(&partial_word))
                                     .map(|x| x.to_string())

--- a/src/console.rs
+++ b/src/console.rs
@@ -423,7 +423,16 @@ pub(crate) fn console_ui(
                         }
                     }
 
-                    // Clear on ctrl+l
+                    // Clear line on ctrl+c
+                    if keyboard_input_events
+                        .iter()
+                        .any(|&k| k.state.is_pressed() && k.key_code == KeyCode::KeyC)
+                        && (keys.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight]))
+                    {
+                        state.buf.clear();
+                    }
+
+                    // Clear history on ctrl+l
                     if keyboard_input_events
                         .iter()
                         .any(|&k| k.state.is_pressed() && k.key_code == KeyCode::KeyL)

--- a/src/console.rs
+++ b/src/console.rs
@@ -477,19 +477,13 @@ pub(crate) fn console_ui(
                     }
 
                     // Clear line on ctrl+c
-                    if keyboard_input_events
-                        .iter()
-                        .any(|&k| k.state.is_pressed() && k.key_code == KeyCode::KeyC)
-                        && (keys.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight]))
+                    if ui.input(|i| i.modifiers.ctrl & i.key_pressed(egui::Key::C))
                     {
                         state.buf.clear();
                     }
 
                     // Clear history on ctrl+l
-                    if keyboard_input_events
-                        .iter()
-                        .any(|&k| k.state.is_pressed() && k.key_code == KeyCode::KeyL)
-                        && (keys.any_pressed([KeyCode::ControlLeft, KeyCode::ControlRight]))
+                    if ui.input(|i| i.modifiers.ctrl & i.key_pressed(egui::Key::L))
                     {
                         state.scrollback.clear();
                         state.buf = state.buf[0..(state.buf.len() - 1)].to_string();

--- a/src/console.rs
+++ b/src/console.rs
@@ -325,7 +325,6 @@ pub(crate) fn console_ui(
     mut egui_context: EguiContexts,
     config: Res<ConsoleConfiguration>,
     mut keyboard_input_events: EventReader<KeyboardInput>,
-    keys: Res<ButtonInput<KeyCode>>,
     mut state: ResMut<ConsoleState>,
     mut command_entered: EventWriter<ConsoleCommandEntered>,
     mut console_open: ResMut<ConsoleOpen>,


### PR DESCRIPTION
- Pressing tab completes the rest of the command. Continuing to press tab cycles through other potential completions.
   e.g. typing `he` and pressing tab results in `help`. If there's another command called `heat`, pressing tab again could result in `heat`.
- Via a new ConsoleConfiguration field, users can manually add autocompletion for command arguments.
   e.g. after setting up the config, you could type `set_color tur` and pressing tab results in `set_color turquoise`
- Pressing Ctrl + C clears the current line
- Fix the bug where an "L" is printed onto the console line when clearing the console history with Ctrl + L

The autocompletion code is functional but a bit verbose and messy. It annoyingly doesn't move the text cursor to the end of the line after autocompleting, I wasn't sure how to fix that, but it didn't bother me enough to try to figure it out.

I don't use github often so I'm unfamiliar with pull request etiquette, sorry if I put too many changes into a single pull request. I can try to make multiple pull requests for the individual changes if needed.