### PR TITLE
Update to Bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_console"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 authors = ["RichoDemus <git@richodemus.com>"]
 homepage = "https://github.com/RichoDemus/bevy-console"
@@ -10,14 +10,14 @@ license = "MIT"
 readme = "README.md"
 
 [dependencies]
-bevy = { version = "0.13", default-features = false }
+bevy = { version = "0.14", default-features = false }
 clap = { version = "4.5", features = ["derive"] }
 bevy_console_derive = { path = "./bevy_console_derive", version = "0.5.0" }
-bevy_egui = "0.25"
+bevy_egui = "0.28.0"
 shlex = "1.3"
 
 [dev-dependencies]
-bevy = "0.13"
+bevy = "0.14"
 
 [workspace]
 members = ["bevy_console_derive"]

--- a/src/commands/exit.rs
+++ b/src/commands/exit.rs
@@ -15,7 +15,7 @@ pub(crate) fn exit_command(
     mut exit_writer: EventWriter<AppExit>,
 ) {
     if let Some(Ok(_)) = exit.take() {
-        exit_writer.send(AppExit);
+        exit_writer.send(AppExit::Success);
         exit.ok();
     }
 }


### PR DESCRIPTION
This PR updates `bevy-console` to Bevy **0.14**, bumping the version to **0.12.0**.

Fixes #69 