### PR TITLE
Add keyboard and mouse blocking functionality

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -240,6 +240,10 @@ pub struct ConsoleConfiguration {
     pub foreground_color: Color32,
     /// Number of suggested commands to show
     pub num_suggestions: usize,
+    /// Blocks mouse from clicking through console
+    pub block_mouse: bool,
+    /// Blocks keyboard from interacting outside console when active
+    pub block_keyboard: bool,
 }
 
 impl Default for ConsoleConfiguration {
@@ -261,6 +265,8 @@ impl Default for ConsoleConfiguration {
             background_color: Color32::from_black_alpha(102),
             foreground_color: Color32::LIGHT_GRAY,
             num_suggestions: 4,
+            block_mouse: false,
+            block_keyboard: false,
         }
     }
 }
@@ -613,6 +619,42 @@ fn set_cursor_pos(ctx: &Context, id: Id, pos: usize) {
             .cursor
             .set_char_range(Some(CCursorRange::one(CCursor::new(pos))));
         state.store(ctx, id);
+    }
+}
+
+pub fn block_mouse_input(
+    mut mouse: ResMut<ButtonInput<MouseButton>>,
+    config: Res<ConsoleConfiguration>,
+    mut contexts: EguiContexts,
+) {
+    if !config.block_mouse {
+        return;
+    }
+
+    let Some(context) = contexts.try_ctx_mut() else {
+        return;
+    };
+
+    if context.is_pointer_over_area() || context.wants_pointer_input() {
+        mouse.reset_all();
+    }
+}
+
+pub fn block_keyboard_input(
+    mut keyboard_keycode: ResMut<ButtonInput<KeyCode>>,
+    config: Res<ConsoleConfiguration>,
+    mut contexts: EguiContexts,
+) {
+    if !config.block_keyboard {
+        return;
+    }
+
+    let Some(context) = contexts.try_ctx_mut() else {
+        return;
+    };
+
+    if context.wants_keyboard_input() {
+        keyboard_keycode.reset_all();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@
 
 use bevy::prelude::*;
 pub use bevy_console_derive::ConsoleCommand;
-use bevy_egui::EguiPlugin;
+use bevy_egui::{EguiPlugin, EguiSet};
+use console::{block_keyboard_input, block_mouse_input};
 
 use crate::commands::clear::{clear_command, ClearCommand};
 use crate::commands::exit::{exit_command, ExitCommand};
@@ -57,6 +58,9 @@ impl Plugin for ConsolePlugin {
             .add_console_command::<ClearCommand, _>(clear_command)
             .add_console_command::<ExitCommand, _>(exit_command)
             .add_console_command::<HelpCommand, _>(help_command)
+            .add_systems(PreUpdate,
+                (block_mouse_input, block_keyboard_input)
+                .after(EguiSet::ProcessInput).before(EguiSet::BeginPass))
             .add_systems(
                 Update,
                 (


### PR DESCRIPTION
Closes #2 

Lets users opt-in to block keyboard and/or mouse input.

Note -- This does not block mouse input that goes through [bevy_picking](https://docs.rs/bevy_picking/0.15.1/bevy_picking/). For that we need to offer a Resource or the like that lets the user know when the Console window is hovered/active, so the user can then block input through [PickingPlugin](https://docs.rs/bevy_picking/0.15.1/bevy_picking/struct.PickingPlugin.html).

Thoughts on that?