### PR TITLE
remove egui defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bevy = { version = "0.16", default-features = false, features = [
 ] }
 clap = { version = "4.5", features = ["derive"] }
 bevy_console_derive = { path = "./bevy_console_derive", version = "0.5.0" }
-bevy_egui = "0.34"
+bevy_egui = { version = "0.34", default-features = false, features = [ "render", "default_fonts" ] }
 shlex = "1.3"
 ansi-parser = "0.9"
 strip-ansi-escapes = "0.2"


### PR DESCRIPTION
the crate doesn't require all egui features, we can leave some optional to the user (which helps with wasm builds, for example)