### PR TITLE
Fix unused import error by using it.

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -143,7 +143,7 @@ unsafe impl<T: Command> SystemParam for ConsoleCommand<'_, T> {
     fn init_access(
             _state: &Self::State,
             _system_meta: &mut SystemMeta,
-            _component_access_set: &mut bevy::ecs::query::FilteredAccessSet,
+            _component_access_set: &mut FilteredAccessSet,
             _world: &mut World,
         ) {
     }


### PR DESCRIPTION
The linux build was failing due to an import statement not being used. No idea why the two platforms have different cargo rules. Should make the build pass.