### PR TITLE
Make the lib.rs:init test message be a debug! message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ fn have_commands(commands: MessageReader<ConsoleCommandEntered>) -> bool {
 
 /// builds the predictive search engine for completions
 fn init(config: Res<ConsoleConfiguration>, mut cache: ResMut<ConsoleCache>) {
-    println!("lib.rs:init");
+    debug!("lib.rs:init");
     let mut trie_builder = TrieBuilder::new();
     for cmd in config.commands.keys() {
         trie_builder.push(cmd);


### PR DESCRIPTION
I assume the `lib.rs:init` message is a now useless test message, but I'm retaining it as a `debug!` so it can be shown, filtered, and displayed properly if desired.

To be honest, I was partially just committing this to force the github action to re-run. I think the cache needed to be busted, but it looks like you resolved that earlier today.