### PR TITLE
locked default commands behind a feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,14 @@ readme = "README.md"
 
 [dependencies]
 bevy = { version = "0.17", default-features = false, features = [
-    "std",
-    "bevy_log",
+  "std",
+  "bevy_log",
 ] }
 clap = { version = "4.5", features = ["derive"] }
 bevy_console_derive = { path = "./bevy_console_derive", version = "0.5.0" }
 bevy_egui = { version = "0.37", default-features = false, features = [
-    "render",
-    "default_fonts",
+  "render",
+  "default_fonts",
 ] }
 shlex = "1.3"
 ansi-parser = "0.9"
@@ -29,6 +29,9 @@ trie-rs = "0.4"
 bevy = { version = "0.17", features = ["std", "bevy_log"] }
 color-print = { version = "0.3" }
 
-
 [workspace]
 members = ["bevy_console_derive"]
+
+[features]
+default = ["default-commands"]
+default-commands = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub use clap;
 
 // mod color;
 mod color;
+#[cfg(feature = "default-commands")]
 mod commands;
 mod console;
 mod log;
@@ -74,12 +75,15 @@ impl Plugin for ConsolePlugin {
             .init_resource::<ConsoleOpen>()
             .init_resource::<ConsoleCache>()
             .add_message::<ConsoleCommandEntered>()
-            .add_message::<PrintConsoleLine>()
-            .add_console_command::<ClearCommand, _>(clear_command)
+            .add_message::<PrintConsoleLine>();
+
+        #[cfg(feature = "default-commands")]
+        app.add_console_command::<ClearCommand, _>(clear_command)
             .add_console_command::<ExitCommand, _>(exit_command)
-            .add_console_command::<HelpCommand, _>(help_command)
-            // after per-command startup
-            .add_systems(Startup, init.after(ConsoleSet::Startup))
+            .add_console_command::<HelpCommand, _>(help_command);
+
+        // after per-command startup
+        app.add_systems(Startup, init.after(ConsoleSet::Startup))
             .add_systems(
                 PreUpdate,
                 (block_mouse_input, block_keyboard_input)


### PR DESCRIPTION
the main reason i dont like the default commands is because i want to use `exit` for something else, but i dont think its possible to just remove commands.
so i propose that they are locked behind a feature gate (thats enabled by default)