### PR TITLE
Update to bevy_egui 0.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ bevy = { version = "0.17", default-features = false, features = [
 ] }
 clap = { version = "4.5", features = ["derive"] }
 bevy_console_derive = { path = "./bevy_console_derive", version = "0.5.0" }
-bevy_egui = { version = "0.37", default-features = false, features = [
+bevy_egui = { version = "0.38", default-features = false, features = [
   "render",
   "default_fonts",
 ] }

--- a/src/console.rs
+++ b/src/console.rs
@@ -548,6 +548,10 @@ pub(crate) fn console_ui(
                     UiBuilder::new().layout(Layout::bottom_up(Align::Min)),
                     |ui| {
                     
+                    // create the area to show suggestions
+                    let suggestions_area = egui::Area::new(ui.auto_id_with("suggestions"))
+                        .fixed_pos(ui.next_widget_position())
+                        .movable(false);
 
                     // Input
                     let text_edit = TextEdit::singleline(&mut state.buf)
@@ -557,6 +561,35 @@ pub(crate) fn console_ui(
 
                     let text_edit_response = ui.add(text_edit);
 
+                    // show a few suggestions
+                    if text_edit_response.has_focus()
+                        && !state.buf.is_empty()
+                        && !cache.prediction_matches_buffer
+                    {
+
+                        suggestions_area.show(ui.ctx(), |ui| {
+                            ui.set_min_width(config.width);
+
+                            for (i, suggestion) in cache.predictions_cache.iter().enumerate() {
+                                let mut layout_job = egui::text::LayoutJob::default();
+                                let is_highlighted = Some(i) == state.suggestion_index;
+
+                                let mut style = TextFormat {
+                                    font_id: FontId::new(14.0, egui::FontFamily::Monospace),
+                                    color: Color32::WHITE,
+                                    ..default()
+                                };
+
+                                if is_highlighted {
+                                    style.underline = egui::Stroke::new(1., Color32::WHITE);
+                                    style.background = Color32::from_black_alpha(128);
+                                }
+
+                                layout_job.append(suggestion, 0.0, style);
+                                ui.label(layout_job);
+                            }
+                        });
+                    }
 
                     // Separator
                     ui.separator();
@@ -592,39 +625,6 @@ pub(crate) fn console_ui(
                         return;
                     }
 
-                    // show a few suggestions
-                    if text_edit_response.has_focus()
-                        && !state.buf.is_empty()
-                        && !cache.prediction_matches_buffer
-                    {
-                        // create the area to show suggestions
-                        let suggestions_area = egui::Area::new(ui.auto_id_with("suggestions"))
-                            .fixed_pos(ui.next_widget_position())
-                            .movable(false);
-
-                        suggestions_area.show(ui.ctx(), |ui| {
-                            ui.set_min_width(config.width);
-
-                            for (i, suggestion) in cache.predictions_cache.iter().enumerate() {
-                                let mut layout_job = egui::text::LayoutJob::default();
-                                let is_highlighted = Some(i) == state.suggestion_index;
-
-                                let mut style = TextFormat {
-                                    font_id: FontId::new(14.0, egui::FontFamily::Monospace),
-                                    color: Color32::WHITE,
-                                    ..default()
-                                };
-
-                                if is_highlighted {
-                                    style.underline = egui::Stroke::new(1., Color32::WHITE);
-                                    style.background = Color32::from_black_alpha(128);
-                                }
-
-                                layout_job.append(suggestion, 0.0, style);
-                                ui.label(layout_job);
-                            }
-                        });
-                    }
 
                     handle_enter(
                         config,

--- a/src/console.rs
+++ b/src/console.rs
@@ -7,9 +7,9 @@ use bevy::ecs::{
 };
 use bevy::platform::hash::FixedState;
 use bevy::{input::keyboard::KeyboardInput, prelude::*};
-use bevy_egui::egui::{self, Align, ScrollArea, TextEdit};
+use bevy_egui::egui::{self, Align, ScrollArea, TextEdit, UiBuilder};
 use bevy_egui::egui::{text::LayoutJob, text_selection::CCursorRange};
-use bevy_egui::egui::{Context, Id};
+use bevy_egui::egui::{Context, Id, Layout};
 use bevy_egui::{
     egui::{epaint::text::cursor::CCursor, Color32, FontId, TextFormat},
     EguiContexts,
@@ -544,9 +544,24 @@ pub(crate) fn console_ui(
                 ui.style_mut().visuals.extreme_bg_color = config.background_color;
                 ui.style_mut().visuals.override_text_color = Some(config.foreground_color);
 
-                ui.vertical(|ui| {
-                    const WRITE_AREA_HEIGHT: f32 = 30.0;
-                    let scroll_height = ui.available_height() - WRITE_AREA_HEIGHT;
+                ui.scope_builder(
+                    UiBuilder::new().layout(Layout::bottom_up(Align::Min)),
+                    |ui| {
+                    
+
+                    // Input
+                    let text_edit = TextEdit::singleline(&mut state.buf)
+                        .desired_width(f32::INFINITY)
+                        .lock_focus(true)
+                        .font(egui::TextStyle::Monospace);
+
+                    let text_edit_response = ui.add(text_edit);
+
+
+                    // Separator
+                    ui.separator();
+
+                    let scroll_height = ui.available_height();
                     // Scroll area
                     ScrollArea::vertical()
                         .auto_shrink([false, false])
@@ -565,9 +580,6 @@ pub(crate) fn console_ui(
                             }
                         });
 
-                    // Separator
-                    ui.separator();
-
                     // Clear line on ctrl+c
                     if ui.input(|i| i.modifiers.ctrl & i.key_pressed(egui::Key::C)) {
                         state.buf.clear();
@@ -579,14 +591,6 @@ pub(crate) fn console_ui(
                         state.scrollback.clear();
                         return;
                     }
-
-                    // Input
-                    let text_edit = TextEdit::singleline(&mut state.buf)
-                        .desired_width(f32::INFINITY)
-                        .lock_focus(true)
-                        .font(egui::TextStyle::Monospace);
-
-                    let text_edit_response = ui.add(text_edit);
 
                     // show a few suggestions
                     if text_edit_response.has_focus()


### PR DESCRIPTION
When using with bevy-inspector-egui this crate crashes since the EguiContexts are different versions.

I also changed the rendering order of the console window to bottom-to-top so there is no need for a hard coded text editor height. Otherwise I would have had to try to figure out the new height because apparently it changed in the update.