### PR TITLE
Refocus on console after entering a command

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -690,6 +690,8 @@ fn handle_enter(
 ) {
     // Handle enter
     if text_edit_response.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
+        ui.memory_mut(|m| m.request_focus(text_edit_response.id));
+
         // if we have a selected suggestion
         // replace the content of the buffer with it and set the cursor to the end
         if let Some(index) = state.suggestion_index {


### PR DESCRIPTION
This allows you to enter multiple commands in a row without needing to manually re-focus on the console.